### PR TITLE
Add optional LiteLLM proxy (Terminal 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,12 +101,32 @@ python start_backend.py
 npm run dev
 ```
 
+**Terminal 3 - LiteLLM (optional):**
+
+LiteLLM runs as a separate proxy for virtual keys and model management. Default config uses `postgresql://litellm:litellm@localhost:5433/litellm` and UI login `admin` / `demo` (from `.env`).
+
+1. **One-time setup** (from project root, with venv activated). This creates `.env` from `.env.example` if needed and generates the LiteLLM Prisma client:
+   ```bash
+   cp .env.example .env
+   ./scripts/setup_litellm.sh
+   ```
+
+2. **If your Postgres or UI credentials differ:** edit `litellm/config.yaml` (e.g. `general_settings.database_url`) and `.env` (`UI_USERNAME`, `UI_PASSWORD`).
+
+3. **Start the LiteLLM proxy** in Terminal 3:
+   ```bash
+   litellm --config litellm/config.yaml
+   ```
+
+4. Open **http://localhost:4000/ui**, sign in with `UI_USERNAME` / `UI_PASSWORD` from `.env`. Add models and mint keys there. Master key for API: `sk-demo-master-key` (or set `LITELLM_MASTER_KEY` in `.env`).
+
 ## 🌐 Access Points
 
 - **Demo Page**: http://localhost:3000
 - **Admin Console**: http://localhost:3000/admin
 - **Backend API**: http://localhost:8000
 - **API Documentation**: http://localhost:8000/docs (if available)
+- **LiteLLM Proxy** (optional): http://localhost:4000 — **LiteLLM UI**: http://localhost:4000/ui
 
 ## ⚙️ Configuration
 

--- a/litellm/config.yaml
+++ b/litellm/config.yaml
@@ -1,0 +1,9 @@
+# LiteLLM Proxy config – no API keys or models in file; add those via UI (http://localhost:4000/ui).
+# Edit database_url below if your Postgres is elsewhere. UI login: set UI_USERNAME and UI_PASSWORD in .env.
+# See: https://docs.litellm.ai/docs/proxy/config_settings and https://docs.litellm.ai/docs/proxy/ui
+
+general_settings:
+  master_key: sk-demo-master-key
+  database_url: postgresql://litellm:litellm@localhost:5433/litellm
+
+model_list: []

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,5 @@ markdown==3.5.1
 pandas==2.1.4
 requests==2.31.0
 httpx==0.25.2
-
+litellm[proxy]
+prisma

--- a/scripts/setup_litellm.sh
+++ b/scripts/setup_litellm.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Set up LiteLLM proxy: .env from example (if missing), Prisma client generate, then print next steps.
+# Run from project root. Requires: Postgres (you provide), pip install -r requirements.txt already done.
+set -e
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+echo "LiteLLM setup"
+echo ""
+
+# 1. Ensure .env exists
+if [ ! -f .env ]; then
+  if [ -f .env.example ]; then
+    cp .env.example .env
+    echo "Created .env from .env.example. Edit .env (and litellm/config.yaml if your DB URL differs) as needed."
+  else
+    echo "Create a .env file; see .env.example for UI_USERNAME / UI_PASSWORD. Edit litellm/config.yaml for database_url."
+    exit 1
+  fi
+else
+  echo ".env exists"
+fi
+
+# 2. Prisma client for LiteLLM proxy
+SCHEMA="$(python -c "import site; import os; p=site.getsitepackages()[0]; s=os.path.join(p,'litellm','proxy','schema.prisma'); print(s)" 2>/dev/null)"
+if [ -z "$SCHEMA" ] || [ ! -f "$SCHEMA" ]; then
+  # Fallback for venv
+  for sp in "$ROOT/venv/lib/python"*/site-packages; do
+    if [ -f "$sp/litellm/proxy/schema.prisma" ]; then
+      SCHEMA="$sp/litellm/proxy/schema.prisma"
+      break
+    fi
+  done
+fi
+if [ -n "$SCHEMA" ] && [ -f "$SCHEMA" ]; then
+  prisma generate --schema="$SCHEMA"
+  echo "Generated Prisma client for LiteLLM"
+else
+  echo "Warning: LiteLLM schema not found. Run: pip install -r requirements.txt (includes litellm[proxy]), then re-run this script."
+fi
+
+echo ""
+echo "Next steps:"
+echo "  1. If your Postgres URL or UI login differs: edit litellm/config.yaml (database_url) and .env (UI_USERNAME, UI_PASSWORD)."
+echo "  2. In a new terminal (Terminal 3), run:"
+echo "     litellm --config litellm/config.yaml"
+echo "  3. Open http://localhost:4000/ui and sign in (UI_USERNAME / UI_PASSWORD from .env)."


### PR DESCRIPTION
# Add optional LiteLLM proxy (Terminal 3)

## Summary
Optional LiteLLM proxy for virtual keys and model management via the UI.

## What's in this PR
- **LiteLLM proxy** — Optional third process (Terminal 3); use your own Postgres.
- **Config** — `litellm/config.yaml` with default DB URL and master key; edit for your DB and UI login.
- **Setup script** — `./scripts/setup_litellm.sh` creates `.env` from `.env.example` if needed, runs Prisma generate, prints next steps.
- **README** — "Terminal 3 - LiteLLM" with copy-paste commands.
- **Deps** — `litellm[proxy]` and `prisma` in `requirements.txt`.

## TODO / Next
- Switch the demo's OpenAI integration to LiteLLM so chat goes through the proxy.
- Make model choice agnostic so users can pick any [model supported by LiteLLM](https://models.litellm.ai/) from the demo.
