### PR TITLE
Fix MCP/ToolHive compatibility and improve Docker docs

### DIFF
--- a/Docker.md
+++ b/Docker.md
@@ -1,18 +1,60 @@
-# Instructions on how to Run and/or Build your own Docker Container
+# Running Guard Demo in Docker
 
-## Build the Docker Container:
+These instructions work on **Mac** (Docker Desktop), **Windows** (Docker Desktop), and **Linux** (Docker Engine).
 
-docker build . guard-demo --no-cache
+---
 
-## Run the Container:
+## Build the image
 
+From the project root (where the Dockerfile is):
+
+```bash
+docker build --no-cache -t guard-demo .
+```
+
+---
+
+## Run the container
+
+**Mac / Windows:**
+
+```bash
 docker run -it -p 3000:3000 guard-demo
+```
 
+**Linux** (so the app can reach host services like ToolHive via `host.docker.internal`):
 
+```bash
+docker run -it -p 3000:3000 --add-host=host.docker.internal:host-gateway guard-demo
+```
 
-## Use the pre-build DockerHub container. (Easiest - No need to pull the GIT repository locally and supports amd64 and arm64 processors)
+Then open **http://localhost:3000** in your browser.
 
+---
 
+## Connecting to ToolHive (or other host services)
+
+When the app runs **inside** the container, `127.0.0.1` refers to the container, not your machine. ToolHive and other MCP servers usually run on the **host**, so the app must use the host address.
+
+- **Mac / Windows:** Use the hostname **`host.docker.internal`** in your tool URLs.
+- **Linux:** Use the run command above with `--add-host=host.docker.internal:host-gateway`, then use **`host.docker.internal`** in your tool URLs.
+
+**Example:** If ToolHive gives you an endpoint like `http://127.0.0.1:51003/mcp`, configure the tool in Admin → Tool Management as:
+
+```text
+http://host.docker.internal:51003/mcp
+```
+
+Use the same port ToolHive shows; only change `127.0.0.1` to `host.docker.internal`.
+
+---
+
+## Use the pre-built image (no local build)
+
+Supports **amd64** and **arm64**:
+
+```bash
 docker run -it -p 3000:3000 vmummer/guard-demo
+```
 
-Current version in Docker Repository are amd64 and arm64 
+On Linux, add `--add-host=host.docker.internal:host-gateway` if you need to reach ToolHive or other host services from inside the container.

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,7 +91,6 @@
       "integrity": "sha512-yDBHV9kQNcr2/sUr9jghVyz9C3Y5G2zUM2H2lo+9mKv4sFgbA8s8Z9t8D1jiTkGoO/NoIfKMyKWr4s6CN23ZwQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1450,7 +1449,6 @@
       "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -1512,7 +1510,6 @@
       "integrity": "sha512-gTtSdWX9xiMPA/7MV9STjJOOYtWwIJIYxkQxnSV1U3xcE+mnJSH3f6zI0RYP+ew66WSlZ5ed+h0VCxsvdC1jJg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.41.0",
         "@typescript-eslint/types": "8.41.0",
@@ -1746,7 +1743,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2116,7 +2112,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001737",
         "electron-to-chromium": "^1.5.211",
@@ -2791,7 +2786,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -4813,7 +4807,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5001,7 +4994,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5014,7 +5006,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -5937,7 +5928,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6094,7 +6084,6 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6176,7 +6165,6 @@
       "integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -6270,7 +6258,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },


### PR DESCRIPTION
Summary

Fixes MCP tool connectivity with ToolHive (SSE and Streamable HTTP) specifically for the Filesystem MCP tool for the demo, improves error handling and user-facing messages, and updates Docker documentation for building, running, and using ToolHive from a container.

MCP / ToolHive
SSE endpoints (e.g. .../sse#serverName): URL fragment is never sent over HTTP. The client now sends the fragment as a ?server=... query parameter and an X-MCP-Server header so the ToolHive SSE proxy can route to the correct stdio server.
Streamable HTTP (/mcp): ToolHive’s default endpoint returns SSE-style bodies (data: {...}\n\n). The HTTP transport now parses these so tool discovery and calls work with http://127.0.0.1:PORT/mcp.

Connection errors: SSE reader thread connection failures (e.g. connection refused) are caught and surfaced with a clear message instead of an unhandled exception in the reader thread.
Tool error messages: MCP tool errors are normalized from the content array, and a short hint is added for -35/EAGAIN (e.g. Node stdio / volume mount).

Docker
Build: Corrected build command to docker build --no-cache -t guard-demo . (valid on Mac, Windows, and Linux).
Run: Documented run commands for Mac/Windows and for Linux (with --add-host=host.docker.internal:host-gateway when the app needs to reach the host).
ToolHive from container: Added a section explaining that tool URLs must use host.docker.internal instead of 127.0.0.1 when the app runs in Docker, with an example.

